### PR TITLE
fix: tx search pagination option

### DIFF
--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -582,6 +582,9 @@ input TxSearchOptions {
   events: [Event!]!
   limit: Int!
   offset: Int!
+
+  """Deprecated. Use offset instead."""
+  page: Int
 }
 
 type TxSearchResult {

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -581,7 +581,7 @@ type TxLog {
 input TxSearchOptions {
   events: [Event!]!
   limit: Int!
-  page: Int!
+  offset: Int!
 }
 
 type TxSearchResult {

--- a/src/tx/models/tx-search-options.model.ts
+++ b/src/tx/models/tx-search-options.model.ts
@@ -6,7 +6,7 @@ export class TxSearchOptions {
   limit!: number
 
   @Field(() => Int)
-  page!: number
+  offset!: number
 
   @Field(() => [Event])
   events!: Event[]

--- a/src/tx/models/tx-search-options.model.ts
+++ b/src/tx/models/tx-search-options.model.ts
@@ -8,6 +8,9 @@ export class TxSearchOptions {
   @Field(() => Int)
   offset!: number
 
+  @Field(() => Int, { nullable: true, description: 'Deprecated. Use offset instead.' })
+  page?: number
+
   @Field(() => [Event])
   events!: Event[]
 }

--- a/src/tx/tx.service.ts
+++ b/src/tx/tx.service.ts
@@ -41,7 +41,11 @@ export class TxService {
 
   public async search(options: Partial<TxSearchOptions>): Promise<TxSearchResult> {
     try {
-      const result = await this.lcdService.tx.search(options)
+      const result = await this.lcdService.tx.search({
+        events: options.events,
+        'pagination.offset': options.offset?.toString(),
+        'pagination.limit': options.limit?.toString(),
+      })
 
       return result
     } catch (err) {


### PR DESCRIPTION
Cause of deprecated parameters in LCD's transaction search API.
`pagination.offset` & `pagination.limit` shoud be used rather than `page` and `limit` parameters.

`limit` will be keep used and relayed into `pagination.limit`,
but `page` should be deprecated and it will be **breaking change**.